### PR TITLE
Upload code

### DIFF
--- a/storage/app.py
+++ b/storage/app.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 import time
+import uuid
+import hashlib
 from pydantic import BaseModel
 
 from .settings import settings
@@ -46,6 +48,8 @@ class FileUploadRespose(BaseModel):
     file_size: int
     target_path: str
     copy_time: float
+    uuid: str
+    sha256: str
 
 
 @app.post("/upload")
@@ -61,6 +65,8 @@ async def upload_file(file: UploadFile) -> FileUploadRespose:
     - file_size: the size of the file in bytes
     - target_path: the path where the file was saved
     - copy_time: the time it took to save the file in seconds
+    - uuid: the UUID of the file
+    - sha256: the SHA256 hash of the file
 
     To send the file use the `multipart/form-data` content type. The file should be sent as the value of a field
     named `file`. For example, using HTML forms like this:
@@ -83,18 +89,23 @@ async def upload_file(file: UploadFile) -> FileUploadRespose:
     ```
 
     """
-    # save the file to the raw upload directory
-    target_path = settings.raw_upload_path / file.filename
+    # create a UUID for this file
+    uid = str(uuid.uuid4())
+    # save the file to the raw upload directory - add a UUID to the filename
+    target_path = settings.raw_upload_path / f"{uid}_{file.filename}"
 
     # check if the file already exists
-    # TODO: what do we actually want here? Overwrite? Rename? Error?
     if target_path.exists():
         raise ValueError(f"file already exists: {file.filename}")
 
-    # write the file to the target path
+    # # write the file to the target path
     t1 = time.time()
     with target_path.open("wb") as buffer:
         buffer.write(await file.read())
+
+    # calculate the SHA256 hash of the file
+    with target_path.open("rb") as f:
+        sha256 = hashlib.sha256(f.read()).hexdigest()
     t2 = time.time()
 
     # finally return some info about the uploaded file
@@ -104,4 +115,6 @@ async def upload_file(file: UploadFile) -> FileUploadRespose:
         file_size=file.size,
         target_path=str(target_path),
         copy_time=t2 - t1,
+        uuid=uid,
+        sha256=sha256,
     )

--- a/storage/app.py
+++ b/storage/app.py
@@ -42,7 +42,7 @@ def info() -> InfoResponse:
     return info
 
 
-class FileUploadRespose(BaseModel):
+class FileUploadMetadata(BaseModel):
     filename: str
     content_type: str
     file_size: int
@@ -53,7 +53,7 @@ class FileUploadRespose(BaseModel):
 
 
 @app.post("/upload")
-async def upload_file(file: UploadFile) -> FileUploadRespose:
+async def upload_file(file: UploadFile) -> FileUploadMetadata:
     """
     Upload a file to the server.
 
@@ -109,7 +109,7 @@ async def upload_file(file: UploadFile) -> FileUploadRespose:
     t2 = time.time()
 
     # finally return some info about the uploaded file
-    return FileUploadRespose(
+    metadata = FileUploadMetadata(
         filename=file.filename,
         content_type=file.content_type,
         file_size=file.size,
@@ -118,3 +118,11 @@ async def upload_file(file: UploadFile) -> FileUploadRespose:
         uuid=uid,
         sha256=sha256,
     )
+
+    # save the metadata to a json file of same name
+    metadata_path = settings.raw_upload_path / f"{uid}_{file.filename}.json"
+    with metadata_path.open("w") as f:
+        f.write(metadata.model_dump_json(indent=4))
+
+    # return the metadata
+    return metadata

--- a/storage/app.py
+++ b/storage/app.py
@@ -1,9 +1,11 @@
-from fastapi import FastAPI, UploadFile
+from fastapi import FastAPI, UploadFile, Form
 from fastapi.middleware.cors import CORSMiddleware
 import time
 import uuid
 import hashlib
-from pydantic import BaseModel
+from pydantic import BaseModel  
+from typing import Annotated
+from enum import Enum
 
 from .settings import settings
 from .__version__ import __version__
@@ -42,6 +44,12 @@ def info() -> InfoResponse:
     return info
 
 
+class PlatformEnum(str, Enum):
+    drone = "drone"
+    airborne = "airborne"
+    sattelite = "sattelite"
+
+
 class FileUploadMetadata(BaseModel):
     filename: str
     content_type: str
@@ -50,10 +58,11 @@ class FileUploadMetadata(BaseModel):
     copy_time: float
     uuid: str
     sha256: str
+    platform: PlatformEnum
 
 
 @app.post("/upload")
-async def upload_file(file: UploadFile) -> FileUploadMetadata:
+async def upload_file(file: UploadFile, platform: Annotated[PlatformEnum, Form()]) -> FileUploadMetadata:
     """
     Upload a file to the server.
 
@@ -117,6 +126,7 @@ async def upload_file(file: UploadFile) -> FileUploadMetadata:
         copy_time=t2 - t1,
         uuid=uid,
         sha256=sha256,
+        platform=platform
     )
 
     # save the metadata to a json file of same name

--- a/storage/app.py
+++ b/storage/app.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI, UploadFile, Form
+from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 import time
 import uuid
 import hashlib
+from pathlib import Path
 from pydantic import BaseModel  
 from typing import Annotated
 from enum import Enum
@@ -136,3 +138,20 @@ async def upload_file(file: UploadFile, platform: Annotated[PlatformEnum, Form()
 
     # return the metadata
     return metadata
+
+
+@app.get("/upload_code.py", responses={200: {"content": {"text/x-python": {}}}}, response_class=FileResponse)
+def get_code():
+    """
+    Get the code for the upload client. You can request a working Python script, that can be 
+    used to upload files to the server. The script uses the `httpx` library to send the file
+    and the `tqdm` library to display a progress bar.
+    You need to make sure that you have the `httpx` and `tqdm` libraries installed to use the script.
+
+    ```bash
+    pip install httpx tqdm
+    ```
+
+    """  
+    # create a FastAPI response with content type of Python files
+    return FileResponse(Path(__file__).parent / "upload_client_example.py", media_type="text/x-python")

--- a/storage/upload_client_example.py
+++ b/storage/upload_client_example.py
@@ -1,0 +1,18 @@
+import os
+
+import httpx
+from tqdm import tqdm
+from tqdm.utils import CallbackIOWrapper
+
+URL = 'http://localhost:8000/upload'
+
+
+def upload_file(filename: str, platform: str):
+    # get the file size in bytes
+    file_size = os.path.getsize(filename)
+
+    with open(filename, 'rb') as f:
+        with tqdm(total=file_size, unit='B', unit_scale=True, unit_divisor=1024) as bar:
+            wrapped_file = CallbackIOWrapper(bar.update, f, 'read')
+            httpx.post(URL, files={'file': wrapped_file}, data={'platform': platform})
+


### PR DESCRIPTION
This PR adds an API endpoint that returns the latest Python script to upload data via Python. Right now, I included it as an API endpoint (to, ie. inject auth information directly) to have everything in one repo. Can be moved to a standalone package in the future.

Only merge after docker is implemented and the metadata saving works. (#3 and #5  should be merged)